### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows-DISABLED/ci.yml
+++ b/.github/workflows-DISABLED/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Build and publish to registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: udienz/docker-ansible
           username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore